### PR TITLE
Local setup

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 REACT_APP_RECAPTCHA_SITE_KEY=6LfXLTsdAAAAAOqMXGb9rOqoIpGGPJN9HjcyoUYp
 REACT_APP_API_URL="http://localhost:3001/"
 REACT_APP_AUTHENTICATOR_URL="http://localhost:3002/"
-SURVEY_BUILDER_URL="https://rhomis-survey.stats4sdtest.online/login/"
+REACT_APP_SURVEY_BUILDER_URL="http://survey-builder.test/login/"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Getting Started with Create React App
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app). 
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 * Looking at setting different environments for development, testing, and production. See [here](https://serverless-stack.com/chapters/environments-in-create-react-app.html), [here](https://www.opcito.com/blogs/managing-multiple-environment-configurations-in-react-app), and [here](https://create-react-app.dev/docs/adding-custom-environment-variables/)
 * Testing tutorial available [here](https://www.youtube.com/watch?v=ZmVBCpefQe8). Example testing with API mocks found in [this tutorial](https://testing-library.com/docs/react-testing-library/example-intro/)
@@ -10,4 +10,18 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 * Server mocks made using [this framework](https://github.com/mswjs/examples/tree/master/examples/rest-react)
 * [Tutorial](https://tacomanator.medium.com/environments-with-create-react-app-7b645312c09d) on managing the different environments and how to integrate them into builds
 
+
+# Setup for Local Development
+
+1. Clone this repository
+2. Install npm dependencies: `npm i`
+3. Run the app: `npm start`
+   - By default, it will run on localhost:3000. This is the default for projects created with [Create React App](https://github.com/facebook/create-react-app).
+   - You can change the default port by overwriting the .env file:
+     - `npm start` will use the `.env.development` file. You can overwrite this locally by copying the file to `.env.development.local`.
+     - To update the port, add a new "PORT" variable.
+     - For more information on how Create React App handles .env files, see the documentation [here](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env)
+
+
+This app depends on the [Rhomis Authenticator App](https://github.com/l-gorman/rhomis-authenticator) to manage users and authentication. You should run that node app alongside on another localhost port during development.
 

--- a/src/components/login-component/login-component.js
+++ b/src/components/login-component/login-component.js
@@ -119,6 +119,7 @@ function LoginCard(props) {
                             />
                             Loading</Button> :
                             <Button className="login-buttons"
+                                type="submit"
                                 variant="dark"
                                 onClick={async (event) => {
                                     setLoading(true)

--- a/src/components/navigation-bar/navigation-bar-component.js
+++ b/src/components/navigation-bar/navigation-bar-component.js
@@ -7,11 +7,11 @@ import { MdOutlineMenu } from 'react-icons/md'
 import axios from 'axios';
 
 import './navigation-bar-component.css'
-/* 
+/*
 Setting up a standard react navbar to navigation component. Please
 note that if you want to maintain state or context between routes,
 you must use the 'react-router-dom' "link". I have integrated
-this with the Nav.Link component 
+this with the Nav.Link component
 */
 
 
@@ -103,7 +103,7 @@ export default function MainNavbar(props) {
                             <Nav.Link className="side-bar-link" as={Link} onClick={() => { handleClose() }} to="/">Portal</Nav.Link>
                         </div>
                         <div className="side-bar-item">
-                            <form style={{ "width": "100%" }} method="post" action={"https://rhomis-survey.stats4sdtest.online/login"} class="inline">
+                            <form style={{ "width": "100%" }} method="post" action={process.env.REACT_APP_SURVEY_BUILDER_URL} class="inline">
                                 <input type="hidden" name="token" value={authToken} />
                                 <input type="hidden" name="redirect_url" value="/admin/xlsform/create" />
                                 <input className="form-link" type="submit" value="Build a Survey"

--- a/src/components/portal-component/portal-data.js
+++ b/src/components/portal-component/portal-data.js
@@ -1,17 +1,17 @@
 // Copyright (C) 2022 Léo Gorman
-// 
+//
 // This file is part of rhomis-data-app.
-// 
+//
 // rhomis-data-app is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // rhomis-data-app is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with rhomis-data-app.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -26,7 +26,7 @@ export const PortalDataAll = [
         label: "surveyBuilder",
         text: "Get started straight away. Build a survey, collect test-data, and view your data.",
         icon: RiSurveyFill,
-        link: "https://rhomis-survey.stats4sdtest.online/login/",
+        link: process.env.REACT_APP_SURVEY_BUILDER_URL,
         external: true,
     },
     {


### PR DESCRIPTION
This PR fixes a few things to make setting up a local development environment easier, including:
 - turns some hardcoded strings into .env variable references (e.g. survey builder url).
 - adds some more setup instructions to the Readme. 

It also allows users to press 'enter' on the login form instead of needing to specifically click the login button. (Very minor thing, but needing to login a lot for testing things encouraged me to add this!)

More significant changes to match the new-draft from published form user flow coming in a separate PR!